### PR TITLE
Fix Swift Package Manager error.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
         "state": {
           "branch": null,
-          "revision": "32573d05b91d8b7349ca31b4726e80212483f02a",
-          "version": "4.8.0"
+          "revision": "75bba56748359f297a83f620d45f72cf4ebee4e7",
+          "version": "4.8.2"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "86c579d280d629416c7bd9d32a5dfacab8e0b0b4",
-          "version": "1.2.0"
+          "revision": "7bf52ab1f5ee87aeb89f2a6b9bfc6369408476f7",
+          "version": "1.5.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI",
         "state": {
           "branch": null,
-          "revision": "fb076cba39c679da4e27813518d8860d8815a25b",
-          "version": "5.2.1"
+          "revision": "2f9325de7dcaa368ce5a3710b04d9df572725b14",
+          "version": "5.3.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,9 +11,9 @@ let package = Package(
             targets: ["Mask-RCNN-CoreML"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.2.0"),
-        .package(url: "https://github.com/jakeheis/SwiftCLI", from: "5.2.1"),
-        .package(url: "https://github.com/Alamofire/Alamofire.git", from: "4.8.0")
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.5.0"),
+        .package(url: "https://github.com/jakeheis/SwiftCLI", from: "5.3.0"),
+        .package(url: "https://github.com/Alamofire/Alamofire.git", from: "4.8.2")
     ],
     targets: [
         .target(

--- a/Sources/maskrcnn/Docker.swift
+++ b/Sources/maskrcnn/Docker.swift
@@ -5,7 +5,7 @@ class Docker {
     
     class var installed:Bool {
         do {
-            let _ = try SwiftCLI.capture("docker",
+            let _ = try Task.capture("docker",
                                          arguments:["version"])
             return true
         } catch {
@@ -28,7 +28,7 @@ class Docker {
     }
     
     func build(verbose:Bool = false) throws {
-        let result = try SwiftCLI.capture("docker",
+        let result = try Task.capture("docker",
                                           arguments:["build", "-t", self.name, "."],
                                           directory:self.buildURL.relativePath)
         if(verbose) {
@@ -45,7 +45,7 @@ class Docker {
         }
         allArguments.append(self.name)
         allArguments.append(contentsOf:arguments)
-        let result = try SwiftCLI.capture("docker", arguments:allArguments)
+        let result = try Task.capture("docker", arguments:allArguments)
         if(verbose) {
             print(result.stdout)
         }


### PR DESCRIPTION
- Use Task.capture instead of SwiftCLI.capture to solve SiftCLI issue.
```
$ swift run maskrcnn download example
/Users/poly/ws/Mask-RCNN-CoreML/Sources/maskrcnn/Docker.swift:8:34: error: 'capture(_:arguments:directory:)' has been renamed to 'Task.capture'
            let _ = try SwiftCLI.capture("docker",
                                 ^~~~~~~
                                 Task.capture
SwiftCLI.capture:2:13: note: 'capture(_:arguments:directory:)' has been explicitly marked unavailable here
public func capture(_ executable: String, arguments: [String], directory: String? = nil) throws -> SwiftCLI.CaptureResult
            ^
/Users/poly/ws/Mask-RCNN-CoreML/Sources/maskrcnn/Docker.swift:48:35: error: 'capture(_:arguments:directory:)' has been renamed to 'Task.capture'
        let result = try SwiftCLI.capture("docker", arguments:allArguments)
                                  ^~~~~~~
                                  Task.capture
SwiftCLI.capture:2:13: note: 'capture(_:arguments:directory:)' has been explicitly marked unavailable here
public func capture(_ executable: String, arguments: [String], directory: String? = nil) throws -> SwiftCLI.CaptureResult
            ^
```

- Update dependencies to solve manifest parse error.
```
$ swift run maskrcnn download example
Fetching https://github.com/jakeheis/SwiftCLI
Fetching https://github.com/Alamofire/Alamofire.git
Fetching https://github.com/apple/swift-protobuf.git
https://github.com/Alamofire/Alamofire.git @ 4.8.0: error: manifest parse error(s):
/var/folders/yl/hzrq7fjd3j96yfsqwzlmcgmm0000gr/T/TemporaryFile.2P2hUs.swift:40:29: error: cannot convert value of type 'Int' to expected element type 'SwiftVersion'
    swiftLanguageVersions: [3, 4]
```